### PR TITLE
Use babbage and not babbage-workspace

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,7 +2,7 @@
 title: Haushalt Rheinland-Pfalz
 ---
 <div ng-controller="DemoCtrl">
-  <babbage-workspace endpoint="http://52.23.213.247/api/babbage" cube="rp-test" state="state">
+  <babbage endpoint="http://52.23.213.247/api/babbage" cube="rp-test" state="state">
   <filter filter="einahmenausgaben"></filter>
   <div class="btn-group" dropdown ng-show="einahmenausgaben.length">
     &mdash;
@@ -17,5 +17,5 @@ title: Haushalt Rheinland-Pfalz
   </div>
       <babbage-treemap drilldown="funktionbezeichnung.funktionbezeichnung" aggregates=regv2016.sum>
       </babbage-treemap>
-  </babbage-workspace>
+  </babbage>
 </div>


### PR DESCRIPTION
## What does this PR do?

It removes the workspace and just uses plain babbage
