### PR TITLE
Use german locale for number formatting

### DIFF
--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -1,5 +1,21 @@
 var demo = angular.module('demo', ['ngRoute', 'ngBabbage', 'angular.filter', 'ui.bootstrap', 'ui.select']);
 
+d3.locale.de_DE = d3.locale({
+  decimal: ",",
+  thousands: ".",
+  grouping: [3],
+  currency: ["", " €"],
+  dateTime: "%A, der %e. %B %Y, %X",
+  date: "%d.%m.%Y",
+  time: "%H:%M:%S",
+  periods: ["AM", "PM"], // unused
+  days: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
+  shortDays: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+  months: ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"],
+  shortMonths: ["Jan", "Feb", "Mrz", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"]
+});
+
+ngBabbageGlobals.numberFormat = d3.locale.de_DE.numberFormat("$,.")
 demo.controller('DemoCtrl', function ($scope) {
   $scope.einahmeAusgabe = 'Einnahmen';
 	$scope.defaultCut = ['einnahmeausgabe.einnahmeausgabe:Einnahme'];


### PR DESCRIPTION
## What does this PR do?

It adds german locale for d3 and updates the `ngBabbageGlobals.numberFormat` to use the new german locale.
### Screenshots

<img width="247" alt="bildschirmfoto 2016-01-12 um 15 49 23" src="https://cloud.githubusercontent.com/assets/688980/12266565/1a0105b4-b944-11e5-8983-1e51ec64eea8.png">
<img width="106" alt="bildschirmfoto 2016-01-12 um 15 49 29" src="https://cloud.githubusercontent.com/assets/688980/12266566/1a23d63e-b944-11e5-8ef1-1a0217520871.png">
