### PR TITLE
Add spacing to key for Kapitel (length 4)

### DIFF
--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -63,8 +63,12 @@ numberOfLeadingZeros = function(key) {
   }
 };
 addSpacingToKey = function(text) {
-  var position = 3;
+  var position = 3,
+      kapitelLength = 4;
   if(text.length <= position) { return text; }
+  if(text.length === kapitelLength) {
+    return [text.slice(0, 1), " ", text.slice(1)].join('');
+  }
   return [text.slice(0, position), " ", text.slice(position)].join('');
 };
 ngBabbageGlobals.treemapHtmlFunc = function(d) {


### PR DESCRIPTION
If the key length is 4 it is of type Kapitel. Add spacing between the second and third character. if it's not add to third and foruth position.
