### PR TITLE
Table header naming

### DIFF
--- a/source/javascripts/treemapTable.js
+++ b/source/javascripts/treemapTable.js
@@ -4,7 +4,7 @@ demo.directive('treemapTable', ['$rootScope', '$http', function($rootScope, $htt
     replace: true,
     require: '^babbage',
     scope: { showKey: '=?' },
-    template: '<table class="treemap-table table table-condensed"><thead> <tr> <th class="color">&nbsp;</th><th class="key" ng-show="showKey" ng-click="sort(\'key\');" ng-class="{ sort: activeOrder(\'key\') }"># <span class="caret"></span></th> <th ng-click="sort(\'name\')" ng-class="{ sort: activeOrder(\'name\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">{{nameTitle}}<span class="caret"></span></th> <th class="num betrag" ng-click="sort(\'value\')" ng-class="{ sort: activeOrder(\'value\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">Betrag<span class="caret"></span></th> <th class="num" ng-click="sort(\'value\')" ng-class="{ sort: activeOrder(\'value\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">Anteil<span class="caret"></span></th> </tr></thead><tbody> <tr ng-repeat="row in rows"> <td class="color"> <i ng-style="{color: row.color};" class="fa fa-square"></i></td><td class="key" ng-show="showKey"> {{row.key}} </td><td><a href ng-click="setTile(row);"> {{row.name}} </a></td> <td class="num">{{row.value_fmt}}</td> <td class="num">{{row.percentage}}</td> </tr> </tbody><tfoot><tr> <th> Summe </th> <th></th><th ng-show="showKey"></th><th class="num">{{summary.value_fmt}}</th> <th class="num">100%</th> </tr></tfoot></table>',
+    template: '<table class="treemap-table table table-condensed"><thead> <tr> <th class="key" ng-show="showKey" colspan="2" ng-click="sort(\'key\');" ng-class="{ sort: activeOrder(\'key\') }">{{keyTitle}} <span class="caret"></span></th> <th ng-click="sort(\'name\')" ng-class="{ sort: activeOrder(\'name\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">{{nameTitle}}<span class="caret"></span></th> <th class="num betrag" ng-click="sort(\'value\')" ng-class="{ sort: activeOrder(\'value\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">Betrag<span class="caret"></span></th> <th class="num" ng-click="sort(\'value\')" ng-class="{ sort: activeOrder(\'value\'), asc: activeDirection(\'asc\'), desc: activeDirection(\'desc\')}">Anteil<span class="caret"></span></th> </tr></thead><tbody> <tr ng-repeat="row in rows"> <td class="color"> <i ng-style="{color: row.color};" class="fa fa-square"></i></td><td class="key" ng-show="showKey"> {{row.key}} </td><td><a href ng-click="setTile(row);"> {{row.name}} </a></td> <td class="num">{{row.value_fmt}}</td> <td class="num">{{row.percentage}}</td> </tr> </tbody><tfoot><tr> <th colspan="2"> Summe </th> <th ng-show="showKey"></th><th class="num">{{summary.value_fmt}}</th> <th class="num">100%</th> </tr></tfoot></table>',
     link: function(scope, element, attrs, babbageCtrl) {
       var orderKeys = {};
       scope.showKey = angular.isDefined(scope.showKey) ? scope.showKey: false;
@@ -76,7 +76,8 @@ demo.directive('treemapTable', ['$rootScope', '$http', function($rootScope, $htt
         areaRef = areaRef ? [areaRef] : defaultArea(model);
 
         scope.rows = [];
-        scope.nameTitle = model.dimensions[tileRef].label;
+        scope.keyTitle = model.dimensions[tileRef].label;
+        scope.nameTitle = model.dimensions[tileRef].label_attribute;
         for (var i in data.cells) {
           var cell = data.cells[i];
           cell.value_fmt = ngBabbageGlobals.numberFormat(Math.round(cell[areaRef]));

--- a/source/javascripts/treemapTable.js
+++ b/source/javascripts/treemapTable.js
@@ -76,8 +76,8 @@ demo.directive('treemapTable', ['$rootScope', '$http', function($rootScope, $htt
         areaRef = areaRef ? [areaRef] : defaultArea(model);
 
         scope.rows = [];
+        scope.nameTitle = scope.showKey ? model.dimensions[tileRef].label_attribute : model.dimensions[tileRef].label;
         scope.keyTitle = model.dimensions[tileRef].label;
-        scope.nameTitle = model.dimensions[tileRef].label_attribute;
         for (var i in data.cells) {
           var cell = data.cells[i];
           cell.value_fmt = ngBabbageGlobals.numberFormat(Math.round(cell[areaRef]));

--- a/source/stylesheets/_table.sass
+++ b/source/stylesheets/_table.sass
@@ -15,15 +15,17 @@ table.treemap-table
   table-layout: fixed
   margin-bottom: 0
   width: 100%
+  th
+    text-transform: capitalize
   .num
     text-align: right
     width: 10%
   .betrag
     width: 18%
   .color
-    width: 2%
+    padding: 5px 0 5px 5px
   .key
-    width: 8%
+    width: 11%
   .caret
     float: right
     width: 0


### PR DESCRIPTION
show the label_attribute as the description name only if the key is to be shown. otherwise use the label.

very specific to RP.
