### PR TITLE
Align the table header to the right for num columns

### DIFF
--- a/source/stylesheets/_table.sass
+++ b/source/stylesheets/_table.sass
@@ -48,11 +48,11 @@ table.treemap-table
     text-align: right
     width: 10%
     .th-inner
-      padding-left: 3%
+      width: 8%
   .betrag
     width: 18%
     .th-inner
-      padding-left: 10%
+      width: 17%
   .color
     padding: 5px 0 5px 5px
   .key


### PR DESCRIPTION
use the same width as the parent th and then text-align right
